### PR TITLE
Remove pull_request in github acitons

### DIFF
--- a/.github/workflows/publish-on-npmjs.yaml
+++ b/.github/workflows/publish-on-npmjs.yaml
@@ -10,16 +10,6 @@ on:
         - "./*.json"
         - "./*.js"
         - ".github/workflows/publish-on-npmjs.yml"
-  pull_request:
-      branches:
-        - main 
-        - dev
-      tags:
-        - 'v*'
-      paths: 
-        - "src/**"
-        - "./*.json"
-        - "./*.js"
   
   workflow_dispatch:
 


### PR DESCRIPTION
# Description of change

Remove pull_request in github actions to avoid publish npm in a pr. Npm should only be published when pushing to main

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Open a pull request and check that it is not updated until it is pushed to main