### PR TITLE
15 add dialog before revoking subscription

### DIFF
--- a/src/lib/components/streams/subscription.svelte
+++ b/src/lib/components/streams/subscription.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type { Subscription } from '@iota/is-client'
-    import { Button, Spinner, ModalBody, ModalFooter, ModalHeader, } from 'sveltestrap'
+    import { Button, Spinner, ModalBody, ModalFooter, ModalHeader } from 'sveltestrap'
     // We have to import Modal this way, otherwise it shouts SSR issues.
     import Modal from 'sveltestrap/src/Modal.svelte'
 
@@ -11,9 +11,10 @@
     export let handleAcceptSubscription: (subscriptionId: string) => Promise<void> = () => Promise.resolve()
     export let handleRejectSubscription: (subscriptionId: string) => Promise<void> = () => Promise.resolve()
 
-    let isOpen = false;   
-
-    let onModalClose = () => {return};
+    let isOpen = false
+    let onModalClose = () => {
+        isOpen = false
+    }
 
     let isAccepting: boolean = false
     let isRejecting: boolean = false
@@ -64,13 +65,13 @@
                         outline
                         color="danger"
                         disabled={isAccepting || isRejecting}
-                        on:click={() => isOpen = true}
+                        on:click={() => (isOpen = true)}
                     >
                         <div class="d-flex justify-content-center align-items-center">
                             {isRejecting ? 'Revoking...' : 'Revoke'}
                             {#if isRejecting}
                                 <div class="ms-2">
-                                    <Spinner size="sm" type="border" color="success" />
+                                    <Spinner size="sm" type="border" color="danger" />
                                 </div>
                             {/if}
                         </div>
@@ -86,17 +87,16 @@
                             <ModalFooter>
                                 <Button
                                     color="danger"
-                                    on:click={() => handleReject()}
+                                    on:click={() => {
+                                        handleReject()
+                                        onModalClose()
+                                    }}
                                 >
-                                    {#if isRejecting}
-                                        <div class="ms-2">
-                                            <Spinner size="sm" type="border" color="success" />
-                                        </div>
-                                    {:else}
-                                        Yes, revoke
-                                    {/if}
+                                    Yes, revoke
                                 </Button>
-                                <Button color="secondary" on:click={onModalClose}>Cancel</Button>
+                                <Button color="secondary" disabled={isAccepting || isRejecting} on:click={onModalClose}
+                                    >Cancel</Button
+                                >
                             </ModalFooter>
                         </div>
                     </Modal>

--- a/src/lib/components/streams/subscription.svelte
+++ b/src/lib/components/streams/subscription.svelte
@@ -12,7 +12,7 @@
     export let handleRejectSubscription: (subscriptionId: string) => Promise<void> = () => Promise.resolve()
 
     let isOpen = false
-    let onModalClose = () => {
+    const onModalClose = () => {
         isOpen = false
     }
 

--- a/src/lib/components/streams/subscription.svelte
+++ b/src/lib/components/streams/subscription.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import type { Subscription } from '@iota/is-client'
-    import { Button, Spinner } from 'sveltestrap'
+    import { Button, Spinner, ModalBody, ModalFooter, ModalHeader, } from 'sveltestrap'
+    // We have to import Modal this way, otherwise it shouts SSR issues.
+    import Modal from 'sveltestrap/src/Modal.svelte'
 
     export let allowAcceptAction: boolean = false
     export let allowRejectAction: boolean = false
@@ -8,6 +10,10 @@
     export let label: string = 'Subscriber Id'
     export let handleAcceptSubscription: (subscriptionId: string) => Promise<void> = () => Promise.resolve()
     export let handleRejectSubscription: (subscriptionId: string) => Promise<void> = () => Promise.resolve()
+
+    let isOpen = false;   
+
+    let onModalClose = () => {return};
 
     let isAccepting: boolean = false
     let isRejecting: boolean = false
@@ -58,7 +64,7 @@
                         outline
                         color="danger"
                         disabled={isAccepting || isRejecting}
-                        on:click={handleReject}
+                        on:click={() => isOpen = true}
                     >
                         <div class="d-flex justify-content-center align-items-center">
                             {isRejecting ? 'Revoking...' : 'Revoke'}
@@ -69,6 +75,31 @@
                             {/if}
                         </div>
                     </Button>
+                    <Modal {isOpen} toggle={onModalClose}>
+                        <div class="p-3 d-flex flex-column">
+                            <ModalHeader toggle={onModalClose}>Are you sure?</ModalHeader>
+                            <ModalBody>
+                                <div class="text-break">
+                                    Subscription of ID <span class="fw-light">{subscription?.id}</span> is going to be rejected.
+                                </div>
+                            </ModalBody>
+                            <ModalFooter>
+                                <Button
+                                    color="danger"
+                                    on:click={() => handleReject()}
+                                >
+                                    {#if isRejecting}
+                                        <div class="ms-2">
+                                            <Spinner size="sm" type="border" color="success" />
+                                        </div>
+                                    {:else}
+                                        Yes, revoke
+                                    {/if}
+                                </Button>
+                                <Button color="secondary" on:click={onModalClose}>Cancel</Button>
+                            </ModalFooter>
+                        </div>
+                    </Modal>
                 {/if}
             </div>
         {/if}


### PR DESCRIPTION
# Description of change

Before a subscription is rejected a dialog pops up to be double sure that this is wanted.

## Type of change

-   Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
Manually by creating a stream with one identity, subscribe with another identity to this stream and reject this subscription with the first identity.

## Change checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
