### PR TITLE
Fixed pagination problem

### DIFF
--- a/src/lib/components/identity/identity-manager.svelte
+++ b/src/lib/components/identity/identity-manager.svelte
@@ -137,7 +137,7 @@
             searchByType: _isType(get(identitySearchQuery)),
             searchByUsername: !_isType(get(identitySearchQuery)),
             limit: DEFAULT_SDK_CLIENT_REQUEST_LIMIT,
-            index: entries / DEFAULT_SDK_CLIENT_REQUEST_LIMIT,
+            index: Math.ceil(entries / DEFAULT_SDK_CLIENT_REQUEST_LIMIT),
         })
         searchIdentitiesResults.update((results) => [...results, ...newIdentities])
     }


### PR DESCRIPTION
# Description of change

Because the index was calculated by division it was always a decimal number which is not working with the API.

## Type of change

<!-- Choose a type of change, and delete any options that are not relevant. -->

-   Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Created 51. Identities to test the load more button.

## Change checklist

-   [x] I have performed a self-review of my own code
