### PR TITLE
Fix logout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@iota/is-ui-components",
-    "version": "0.0.52",
+    "version": "0.0.53",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@iota/is-ui-components",
-            "version": "0.0.52",
+            "version": "0.0.53",
             "dependencies": {
                 "@iota/is-client": "^0.1.10",
                 "bootstrap": "^5.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@iota/is-ui-components",
     "type": "module",
-    "version": "0.0.52",
+    "version": "0.0.53",
     "description": "Svelte UI components for IOTA Integration Services",
     "scripts": {
         "dev": "svelte-kit dev --port ${PORT:-3044}",

--- a/src/lib/app/base.ts
+++ b/src/lib/app/base.ts
@@ -30,8 +30,8 @@ authenticationData?.subscribe(($authenticationData) => {
 })
 
 function getUserRole(jwtToken: string): UserRoles {
-    if (typeof window !== 'undefined') {
-        const payload: JwtUser = JSON.parse(window?.atob(jwtToken?.split('.')?.[1])).user
+    if (window?.atob && jwtToken) {
+        const payload: JwtUser = JSON.parse(window?.atob(jwtToken?.split('.')?.[1]))?.user
         return payload.role
     }
 }

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -28,7 +28,7 @@
 
     async function _logout() {
         logout()
-        goto('/')
+        await goto('/')
     }
 
     function handleCollapse(event: CustomEvent) {

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -10,6 +10,8 @@
 <script lang="ts">
     import { startPollExpirationCheckJWT, stopPollExpirationCheckJWT } from '$lib/app/base'
     import { Icon, NotificationManager } from '$lib/components'
+    import { goto } from '$app/navigation'
+    import { logout, isAuthenticated } from '$lib/app'
     import '$lib/scss/index.scss'
     import 'bootstrap/dist/css/bootstrap.min.css'
     import { onMount } from 'svelte'
@@ -23,6 +25,11 @@
             stopPollExpirationCheckJWT()
         }
     })
+
+    async function _logout() {
+        logout()
+        goto('/')
+    }
 
     function handleCollapse(event) {
         isOpen = event.detail.isOpen
@@ -47,6 +54,10 @@
                     <NavLink href={page.url}>{page.title}</NavLink>
                 </NavItem>
             {/each}
+            {#if $isAuthenticated}
+                <NavItem><hr class="me-3" /></NavItem>
+                <NavItem><NavLink on:click={_logout}>Logout</NavLink></NavItem>
+            {/if}
         </Nav>
     </Collapse>
 </Navbar>


### PR DESCRIPTION
Problem:
Logout threw an error cause of the userRole parsing using the jwt.

Previously:
Navigate to `http://localhost:3044/identity-manager` it will throw an error if you are not logged in since userRole can't be parsed.

Now it won't throw an error anymore.

